### PR TITLE
Buttons fix on window resize

### DIFF
--- a/lib/jquery.tinycarousel.js
+++ b/lib/jquery.tinycarousel.js
@@ -82,7 +82,8 @@
 
             $overview.append($slides.slice(0, slidesVisible).clone().addClass("mirrored"));
             $overview.css(sizeLabel.toLowerCase(), slideSize * (self.slidesTotal + slidesVisible));
-
+            setButtons();
+            
             return self;
         };
 


### PR DESCRIPTION
When the users resize their window or update the carousel the buttons were not updated if infinite was set to false
