### PR TITLE
Infinite loop extended

### DIFF
--- a/lib/jquery.tinycarousel.js
+++ b/lib/jquery.tinycarousel.js
@@ -22,7 +22,7 @@
         ,   animation: true
         ,   animationTime: 1000
         ,   infinite: true
-		,   moveNumber: 1
+	,   moveNumber: 1
         }
     ;
 
@@ -128,7 +128,7 @@
             self.slidesTotal = $slides.length;
             self.slideCurrent = self.options.start || 0;
             slidesVisible = Math.ceil(viewportSize / slideSize);
-			self.moveNumber	= (self.options.moveNumber > self.slidesTotal) ? self.slidesTotal : self.options.moveNumber;
+	    self.moveNumber	= (self.options.moveNumber > self.slidesTotal) ? self.slidesTotal : self.options.moveNumber;
 
             $overview.append($slides.slice(0, self.slidesTotal).clone().addClass("mirrored"));
             $overview.append($slides.slice(0, self.slidesTotal).clone().addClass("mirrored"));

--- a/lib/jquery.tinycarousel.js
+++ b/lib/jquery.tinycarousel.js
@@ -83,8 +83,9 @@
             self.slideCurrent = self.options.start || 0;
             slidesVisible     = Math.ceil(viewportSize / slideSize);
 
-            $overview.append($slides.slice(0, slidesVisible).clone().addClass("mirrored"));
-            $overview.css(sizeLabel.toLowerCase(), slideSize * (self.slidesTotal + slidesVisible));
+            $overview.append($slides.slice(0, self.slidesTotal).clone().addClass("mirrored"));
+            $overview.append($slides.slice(0, self.slidesTotal).clone().addClass("mirrored"));
+            $overview.css(sizeLabel.toLowerCase(), slideSize * self.slidesTotal * 3);
 
             setButtons();
 
@@ -149,18 +150,18 @@
         this.move = function(index)
         {
             slideIndex        = index;
-            self.slideCurrent = slideIndex % self.slidesTotal;
+            self.slideCurrent = index;
 
             if(slideIndex < 0)
             {
-                self.slideCurrent = slideIndex = self.slidesTotal - self.moveNumber;
-                $overview.css(posiLabel, -(self.slidesTotal) * slideSize);
+            	self.slideCurrent = slideIndex = index + self.slidesTotal;
+                $overview.css(posiLabel, -(slideIndex + self.moveNumber) * slideSize);
             }
             
-            if(slideIndex > self.slidesTotal)
+            if(slideIndex > (self.slidesTotal*2))
             {
-                self.slideCurrent = slideIndex = self.moveNumber;
-                $overview.css(posiLabel, 0);
+            	self.slideCurrent = slideIndex = index - self.slidesTotal;
+                $overview.css(posiLabel, -(slideIndex - self.moveNumber) * slideSize);
             }
 
             contentStyle[posiLabel] = -slideIndex * slideSize;

--- a/lib/jquery.tinycarousel.js
+++ b/lib/jquery.tinycarousel.js
@@ -27,6 +27,7 @@
         ,   animation:      true   // false is instant, true is animate.
         ,   animationTime:  1000   // how fast must the animation move in ms?
         ,   infinite:       true   // infinite carousel.
+        ,   moveNumber:     1      // how many slides to move
         }
     ;
 
@@ -56,6 +57,7 @@
         ,   intervalTimer = null
         ;
 
+        this.moveNumber   = 0;
         this.slideCurrent = 0;
         this.slidesTotal  = 0;
 
@@ -77,6 +79,7 @@
             viewportSize      = $viewport[0]["offset" + sizeLabel];
             slideSize         = $slides.first()["outer" + sizeLabel](true);
             self.slidesTotal  = $slides.length;
+            self.moveNumber	  = (self.options.moveNumber > self.slidesTotal) ? self.slidesTotal : self.options.moveNumber;
             self.slideCurrent = self.options.start || 0;
             slidesVisible     = Math.ceil(viewportSize / slideSize);
 
@@ -94,14 +97,14 @@
             {
                 $prev.click(function()
                 {
-                    self.move(--slideIndex);
+                    self.move(slideIndex - self.moveNumber);
 
                     return false;
                 });
 
                 $next.click(function()
                 {
-                    self.move(++slideIndex);
+                    self.move(slideIndex + self.moveNumber);
 
                     return false;
                 });
@@ -128,7 +131,7 @@
 
                 intervalTimer = setTimeout(function()
                 {
-                    self.move(++slideIndex);
+                    self.move(slideIndex + self.moveNumber);
 
                 }, self.options.intervalTime);
             }
@@ -150,13 +153,13 @@
 
             if(slideIndex < 0)
             {
-                self.slideCurrent = slideIndex = self.slidesTotal - 1;
+                self.slideCurrent = slideIndex = self.slidesTotal - self.moveNumber;
                 $overview.css(posiLabel, -(self.slidesTotal) * slideSize);
             }
-
+            
             if(slideIndex > self.slidesTotal)
             {
-                self.slideCurrent = slideIndex = 1;
+                self.slideCurrent = slideIndex = self.moveNumber;
                 $overview.css(posiLabel, 0);
             }
 

--- a/lib/jquery.tinycarousel.js
+++ b/lib/jquery.tinycarousel.js
@@ -1,110 +1,157 @@
-;(function (factory)
-{
-    if (typeof define === 'function' && define.amd)
-    {
+;(function(factory) {
+    if(typeof define === 'function' && define.amd) {
         define(['jquery'], factory);
     }
-    else if (typeof exports === 'object')
-    {
-        factory(require('jquery'));
+    else if(typeof exports === 'object') {
+        module.exports = factory(require('jquery'));
     }
-    else
-    {
+    else {
         factory(jQuery);
     }
 }
-(function ($)
-{
+(function($) {
     var pluginName = "tinycarousel"
     ,   defaults   =
         {
-            start:          0      // The starting slide
-        ,   axis:           "x"    // vertical or horizontal scroller? ( x || y ).
-        ,   buttons:        true   // show left and right navigation buttons.
-        ,   bullets:        false  // is there a page number navigation present?
-        ,   interval:       false  // move to another block on intervals.
-        ,   intervalTime:   3000   // interval time in milliseconds.
-        ,   animation:      true   // false is instant, true is animate.
-        ,   animationTime:  1000   // how fast must the animation move in ms?
-        ,   infinite:       true   // infinite carousel.
-        ,   moveNumber:     1      // how many slides to move
+            start: 0
+        ,   axis: "x"
+        ,   buttons: true
+        ,   bullets: false
+        ,   interval: false
+        ,   intervalTime: 3000
+        ,   animation: true
+        ,   animationTime: 1000
+        ,   infinite: true
+		,   moveNumber: 1
         }
     ;
 
-    function Plugin($container, options)
-    {
-        this.options   = $.extend({}, defaults, options);
-        this._defaults = defaults;
-        this._name     = pluginName;
+    function Plugin($container, options) {
+        /**
+         * The options of the carousel extend with the defaults.
+         *
+         * @property options
+         * @type Object
+         * @default defaults
+         */
+        this.options = $.extend({}, defaults, options);
 
-        var self      = this
+        /**
+         * @property _defaults
+         * @type Object
+         * @private
+         * @default defaults
+         */
+        this._defaults = defaults;
+
+        /**
+         * @property _name
+         * @type String
+         * @private
+         * @final
+         * @default 'tinycarousel'
+         */
+        this._name = pluginName;
+
+        var self = this
         ,   $viewport = $container.find(".viewport:first")
         ,   $overview = $container.find(".overview:first")
-        ,   $slides   = 0
-        ,   $next     = $container.find(".next:first")
-        ,   $prev     = $container.find(".prev:first")
-        ,   $bullets  = $container.find(".bullet")
+        ,   $slides = null
+        ,   $next = $container.find(".next:first")
+        ,   $prev = $container.find(".prev:first")
+        ,   $bullets = $container.find(".bullet")
 
-        ,   viewportSize    = 0
-        ,   contentStyle    = {}
-        ,   slidesVisible   = 0
-        ,   slideSize       = 0
-        ,   slideIndex      = 0
+        ,   viewportSize = 0
+        ,   contentStyle = {}
+        ,   slidesVisible = 0
+        ,   slideSize = 0
+        ,   slideIndex = 0
 
-        ,   isHorizontal  = this.options.axis === 'x'
-        ,   sizeLabel     = isHorizontal ? "Width" : "Height"
-        ,   posiLabel     = isHorizontal ? "left" : "top"
+        ,   isHorizontal = this.options.axis === 'x'
+        ,   sizeLabel = isHorizontal ? "Width" : "Height"
+        ,   posiLabel = isHorizontal ? "left" : "top"
         ,   intervalTimer = null
         ;
 
-        this.moveNumber   = 0;
+        /**
+         * The index of the current slide.
+         *
+         * @property slideCurrent
+         * @type Number
+         * @default 0
+         */
         this.slideCurrent = 0;
-        this.slidesTotal  = 0;
 
-        function initialize()
-        {
+        /**
+         * The number of slides the carousel is currently aware of.
+         *
+         * @property slidesTotal
+         * @type Number
+         * @default 0
+         */
+        this.slidesTotal = 0;
+
+        /**
+         * If the interval is running the value will be true.
+         *
+         * @property intervalActive
+         * @type Boolean
+         * @default false
+         */
+        this.intervalActive = false;
+
+        /**
+         * @method _initialize
+         * @private
+         */
+        function _initialize() {
             self.update();
             self.move(self.slideCurrent);
 
-            setEvents();
+            _setEvents();
 
             return self;
         }
 
-        this.update = function()
-        {
+        /**
+         * You can use this method to add new slides on the fly. Or to let the carousel recalculate itself.
+         *
+         * @method update
+         * @chainable
+         */
+        this.update = function() {
             $overview.find(".mirrored").remove();
 
-            $slides           = $overview.children();
-            viewportSize      = $viewport[0]["offset" + sizeLabel];
-            slideSize         = $slides.first()["outer" + sizeLabel](true);
-            self.slidesTotal  = $slides.length;
-            self.moveNumber	  = (self.options.moveNumber > self.slidesTotal) ? self.slidesTotal : self.options.moveNumber;
+            $slides = $overview.children();
+            viewportSize = $viewport[0]["offset" + sizeLabel];
+            slideSize = $slides.first()["outer" + sizeLabel](true);
+            self.slidesTotal = $slides.length;
             self.slideCurrent = self.options.start || 0;
-            slidesVisible     = Math.ceil(viewportSize / slideSize);
+            slidesVisible = Math.ceil(viewportSize / slideSize);
+			self.moveNumber	= (self.options.moveNumber > self.slidesTotal) ? self.slidesTotal : self.options.moveNumber;
 
             $overview.append($slides.slice(0, self.slidesTotal).clone().addClass("mirrored"));
             $overview.append($slides.slice(0, self.slidesTotal).clone().addClass("mirrored"));
             $overview.css(sizeLabel.toLowerCase(), slideSize * self.slidesTotal * 3);
 
-            setButtons();
+            _setButtons();
 
             return self;
         };
 
-        function setEvents()
-        {
-            if(self.options.buttons)
-            {
-                $prev.click(function()
-                {
+        /**
+         * @method _setEvents
+         * @private
+         */
+        function _setEvents() {
+            if(self.options.buttons) {
+                $prev.click(function() {
                     self.move(slideIndex - self.moveNumber);
 
                     return false;
                 });
 
-                $next.click(function()
-                {
+                $next.click(function() {
                     self.move(slideIndex + self.moveNumber);
 
                     return false;
@@ -113,10 +160,8 @@
 
             $(window).resize(self.update);
 
-            if(self.options.bullets)
-            {
-                $container.on("click", ".bullet", function()
-                {
+            if(self.options.bullets) {
+                $container.on("click", ".bullet", function() {
                     self.move(slideIndex = +$(this).attr("data-slide"));
 
                     return false;
@@ -124,14 +169,20 @@
             }
         }
 
-        this.start = function()
-        {
-            if(self.options.interval)
-            {
+
+        /**
+         * If the interval is stoped start it.
+         *
+         * @method start
+         * @chainable
+         */
+        this.start = function() {
+            if(self.options.interval) {
                 clearTimeout(intervalTimer);
 
-                intervalTimer = setTimeout(function()
-                {
+                self.intervalActive = true;
+
+                intervalTimer = setTimeout(function() {
                     self.move(slideIndex + self.moveNumber);
 
                 }, self.options.intervalTime);
@@ -140,73 +191,99 @@
             return self;
         };
 
-        this.stop = function()
-        {
+        /**
+         * If the interval is running stop it.
+         *
+         * @method start
+         * @chainable
+         */
+        this.stop = function() {
             clearTimeout(intervalTimer);
+
+            self.intervalActive = false;
 
             return self;
         };
 
-        this.move = function(index)
-        {
-            slideIndex        = index;
-            self.slideCurrent = index;
+        /**
+         * Move to a specific slide.
+         *
+         * @method move
+         * @chainable
+         * @param {Number}  [index] The slide to move to.
+         */
+        this.move = function(index) {
+            slideIndex = isNaN(index) ? self.slideCurrent : index;
+            self.slideCurrent = slideIndex % self.slidesTotal;
 
-            if(slideIndex < 0)
-            {
-            	self.slideCurrent = slideIndex = index + self.slidesTotal;
+            if(slideIndex < 0) {
+                self.slideCurrent = slideIndex = index + self.slidesTotal;
                 $overview.css(posiLabel, -(slideIndex + self.moveNumber) * slideSize);
             }
-            
-            if(slideIndex > (self.slidesTotal*2))
-            {
-            	self.slideCurrent = slideIndex = index - self.slidesTotal;
+
+            if(slideIndex > (self.slidesTotal*2)) {
+                self.slideCurrent = slideIndex = index - self.slidesTotal;
                 $overview.css(posiLabel, -(slideIndex - self.moveNumber) * slideSize);
             }
-
             contentStyle[posiLabel] = -slideIndex * slideSize;
 
             $overview.animate(
                 contentStyle
             ,   {
-                    queue    : false
+                    queue : false
                 ,   duration : self.options.animation ? self.options.animationTime : 0
-                ,   always : function()
-                    {
+                ,   always : function() {
+                       /**
+                        * The move event will trigger when the carousel slides to a new slide.
+                        *
+                        * @event move
+                        */
                         $container.trigger("move", [$slides[self.slideCurrent], self.slideCurrent]);
                     }
-            });
+                });
 
-            setButtons();
+            _setButtons();
             self.start();
 
             return self;
         };
 
-        function setButtons()
-        {
-            if(self.options.buttons && !self.options.infinite)
-            {
+        /**
+         * @method _setButtons
+         * @private
+         */
+        function _setButtons() {
+            if(self.options.buttons && !self.options.infinite) {
                 $prev.toggleClass("disable", self.slideCurrent <= 0);
                 $next.toggleClass("disable", self.slideCurrent >= self.slidesTotal - slidesVisible);
             }
 
-            if(self.options.bullets)
-            {
+            if(self.options.bullets) {
                 $bullets.removeClass("active");
                 $($bullets[self.slideCurrent]).addClass("active");
             }
         }
 
-        return initialize();
+        return _initialize();
     }
 
-    $.fn[pluginName] = function(options)
-    {
-        return this.each(function()
-        {
-            if(!$.data(this, "plugin_" + pluginName))
-            {
+    /**
+    * @class tinycarousel
+    * @constructor
+    * @param {Object} options
+        @param {Number}  [options.start=0] The slide to start with.
+        @param {String}  [options.axis=x] Vertical or horizontal scroller? ( x || y ).
+        @param {Boolean} [options.buttons=true] Show previous and next navigation buttons.
+        @param {Boolean} [options.bullets=false] Is there a page number navigation present?
+        @param {Boolean} [options.interval=false] Move to another block on intervals.
+        @param {Number}  [options.intervalTime=3000] Interval time in milliseconds.
+        @param {Boolean} [options.animate=true] False is instant, true is animate.
+        @param {Number}  [options.animationTime=1000] How fast must the animation move in ms?
+        @param {Boolean} [options.infinite=true] Infinite carousel.
+    */
+    $.fn[pluginName] = function(options) {
+        return this.each(function() {
+            if(!$.data(this, "plugin_" + pluginName)) {
                 $.data(this, "plugin_" + pluginName, new Plugin($(this), options));
             }
         });


### PR DESCRIPTION
For more flexibility I added an option to set the number of items moved.
For example you could define the width of the viewport as 4 items wide and move always 4 items at once. 
The endless loop will now also work if the number of items in the loop is not multiples of 4. To allow for this the cloning had to be extended to double the number of items. 
I have not tested vertical movement and bullets, but it should work as well with the changes.

With this addition the carousel is quite flexible and still very lightweight.